### PR TITLE
placeholderの有効チェックがうまく動いていないので修正

### DIFF
--- a/jquery.ah-placeholder.js
+++ b/jquery.ah-placeholder.js
@@ -65,7 +65,7 @@ $.fn.ahPlaceholder = function(options)
     var init    = function()
         {
             // placeholderが有効なら処理を必要としないので終了
-            if ( settings.placeholderAttr === 'placeholder' && ('placeholder' in document.createElement('input')) ) {
+            if (!$.browser.msie) {
                 return;
             }
 

--- a/jquery.ah-placeholder.js
+++ b/jquery.ah-placeholder.js
@@ -24,7 +24,6 @@ $.fn.ahPlaceholder = function(options)
 
     var ngCode  = [
             ' ',  // --------------
-            '0',  // ???
             '9',  // tab
             '16', // shift
             '17', // ctrl


### PR DESCRIPTION
ChromeやFirefoxではplaceholderが有効なはずですが、チェックをすり抜けてしまいます。
主要ブラウザで対応していないのはIEだけなので、IEのみ適応させるくらいでよいのではないでしょうか。
