### PR TITLE
IE9でsubmit時にplacoholderの値が送信されてしまう件

### DIFF
--- a/jquery.ah-placeholder.js
+++ b/jquery.ah-placeholder.js
@@ -92,7 +92,7 @@ $.fn.ahPlaceholder = function(options)
 
             $self.closest('form').submit(function() {
                 if ( self.value === $.data(self, 'placeholder-string')
-                     && $self.css('color') === settings.placeholderColor ) {
+                     && $self.css('color') === $('<div/>').css('color', settings.placeholderColor).css('color')) {
                          self.value = '';
                 }
                 return true;


### PR DESCRIPTION
素晴らしいPluginありがとうございます。
#4 のプルリクの修正Patchです。IE8とIE9で動作確認しています。
