### PR TITLE
fix right-click paste bug (when likeApple mode)

### DIFF
--- a/jquery.ah-placeholder.js
+++ b/jquery.ah-placeholder.js
@@ -85,6 +85,7 @@ $.fn.ahPlaceholder = function(options)
                 $self.bind('mousedown', moveCursorToHead);
                 $self.bind('keydown', onKeydown);
                 $self.bind('keyup', resetPlaceholder);
+                $self.bind('paste', onFocus);
             } else {
                 $self.bind('focus', onFocus);
                 $self.bind('blur', resetPlaceholder);


### PR DESCRIPTION
likeApple:true の場合、プレースフォルダのテキストが表示されている状態で、右クリック→コピーを行うとプレースフォルダテキストにそのままテキストが連結されてしまうというバグがありました(IE/Chromeで確認)。

これを解消するため、pasteイベントでonFocusと同様の処理をバインドしました(contextMenuイベントでもよかったのですが、「入力するまで表示する」というのがこのモードだと思うので、実際に張り付けするイベントの方でバインドしました)。
よろしければ、修正をお願いいたします。
