### PR TITLE
半角/全角キーの入力もスルーする

### DIFF
--- a/jquery.ah-placeholder.js
+++ b/jquery.ah-placeholder.js
@@ -105,7 +105,7 @@ $.fn.ahPlaceholder = function(options)
 
                 if ( ngCode.indexOf('@'+key+'@') !== -1 ) {
                     // tabの入力は認める
-                    return ( key === 9 );
+                    return ( key === 9 || key === 229 );
                 } else {
                     _clearPlaceholder(this);
                 }


### PR DESCRIPTION
半角/全角キーの入力についても無視しないと、likeApple: true の場合に、動きに若干の違和感が残ります。
